### PR TITLE
Test/pyproject

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,5 @@ install:
 
 script:
   - black . --check
-  - find ./ -name "*.py" | isort --check-only
+  - find ./ -name "*.py" | isort --check-only -m 3
     #- pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[tool.black]
+line-length = 80
+target_version = ['py37']
+
+[tool.isort]
+multi_line_output = 3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,0 @@
-[tool.black]
-line-length = 80
-target_version = ['py37']
-
-[tool.isort]
-multi_line_output = 3


### PR DESCRIPTION
CIでblackとisortのimportの仕方が違うのを直した